### PR TITLE
CDRIVER-6424 validate database and collection names

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1105,6 +1105,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-oidc.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-oidc-callback.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-oidc-cache.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-ns-validation.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-opts.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-primary-stepdown.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-queue.c

--- a/src/libmongoc/src/mongoc/mongoc-aggregate-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate-private.h
@@ -34,6 +34,7 @@ BSON_BEGIN_DECLS
 mongoc_cursor_t *
 _mongoc_aggregate(mongoc_client_t *client,
                   const char *ns,
+                  const char *db,
                   mongoc_query_flags_t flags,
                   const bson_t *pipeline,
                   const bson_t *opts,

--- a/src/libmongoc/src/mongoc/mongoc-aggregate.c
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate.c
@@ -184,6 +184,7 @@ fail:
  *       information on how to build aggregation pipelines.
  *
  * Parameters:
+ *       @db: Database name used. Separated from @ns to validate.
  *       @ns: Namespace (or database name for database-level aggregation).
  *       @flags: Bitwise or of mongoc_query_flags_t or 0.
  *       @pipeline: A bson_t containing the pipeline request. @pipeline
@@ -210,6 +211,7 @@ fail:
 mongoc_cursor_t *
 _mongoc_aggregate(mongoc_client_t *client,
                   const char *ns,
+                  const char *db,
                   mongoc_query_flags_t flags,
                   const bson_t *pipeline,
                   const bson_t *opts,
@@ -236,6 +238,7 @@ _mongoc_aggregate(mongoc_client_t *client,
 
    BSON_ASSERT(client);
    BSON_ASSERT(ns);
+   BSON_ASSERT_PARAM(db);
    BSON_ASSERT(pipeline);
 
    bson_init(&cursor_opts);
@@ -270,6 +273,11 @@ _mongoc_aggregate(mongoc_client_t *client,
    }
 
    if (mongoc_cursor_error(cursor, NULL)) {
+      GOTO(done);
+   }
+
+   // `ns` is already joined and cannot be split back into `db` reliably. Check `db` while it is still separate.
+   if (!_mongoc_cursor_check_db_name(cursor, db)) {
       GOTO(done);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2210,6 +2210,10 @@ _mongoc_cse_client_enable_auto_encryption(mongoc_client_t *client,
       GOTO(fail);
    }
 
+   if (!_mongoc_validate_db_name(opts->keyvault_db, -1, error)) {
+      GOTO(fail);
+   }
+
    if (!opts->kms_providers) {
       _mongoc_set_error(
          error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG, "KMS providers option required");
@@ -2341,6 +2345,10 @@ _mongoc_cse_client_pool_enable_auto_encryption(mongoc_topology_t *topology,
       GOTO(fail);
    }
 
+   if (!_mongoc_validate_db_name(opts->keyvault_db, -1, error)) {
+      GOTO(fail);
+   }
+
    if (!opts->kms_providers) {
       _mongoc_set_error(
          error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG, "KMS providers option required");
@@ -2447,6 +2455,10 @@ mongoc_client_encryption_new(mongoc_client_encryption_opts_t *opts, bson_error_t
                         MONGOC_ERROR_CLIENT,
                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
                         "Key vault client and namespace option required");
+      goto fail;
+   }
+
+   if (!_mongoc_validate_db_name(opts->keyvault_db, -1, error)) {
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1471,6 +1471,10 @@ mongoc_client_get_gridfs(mongoc_client_t *client, const char *db, const char *pr
       prefix = "fs";
    }
 
+   if (!_mongoc_validate_db_name(db, -1, error)) {
+      return NULL;
+   }
+
    return _mongoc_gridfs_new(client, db, prefix, error);
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -738,6 +738,12 @@ mongoc_cmd_parts_assemble(mongoc_cmd_parts_t *parts, mongoc_server_stream_t *ser
    BSON_ASSERT(!parts->assembled.command);
    BSON_ASSERT(bson_empty(&parts->assembled_body));
 
+   // The database name is sent as "$db" for OP_MSG or as "<db>.$cmd" for OP_QUERY.
+   // Reject a name the driver cannot forward faithfully, rather than silently targeting a different database.
+   if (parts->assembled.db_name && !_mongoc_validate_db_name(parts->assembled.db_name, -1, error)) {
+      GOTO(done);
+   }
+
    /* begin with raw flags/cmd as assembled flags/cmd, might change below */
    parts->assembled.command = parts->body;
    /* unused in OP_MSG: */

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -740,7 +740,8 @@ mongoc_cmd_parts_assemble(mongoc_cmd_parts_t *parts, mongoc_server_stream_t *ser
 
    // The database name is sent as "$db" for OP_MSG or as "<db>.$cmd" for OP_QUERY.
    // Reject a name the driver cannot forward faithfully, rather than silently targeting a different database.
-   if (parts->assembled.db_name && !_mongoc_validate_db_name(parts->assembled.db_name, -1, error)) {
+   BSON_ASSERT(parts->assembled.db_name);
+   if (!_mongoc_validate_db_name(parts->assembled.db_name, -1, error)) {
       GOTO(done);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -287,6 +287,7 @@ mongoc_collection_aggregate(mongoc_collection_t *collection,       /* IN */
 {
    return _mongoc_aggregate(collection->client,
                             collection->ns,
+                            collection->db,
                             flags,
                             pipeline,
                             opts,
@@ -334,8 +335,12 @@ mongoc_collection_find_with_opts(mongoc_collection_t *collection,
 
    bson_clear(&collection->gle);
 
-   return _mongoc_cursor_find_new(
+   mongoc_cursor_t *const cursor = _mongoc_cursor_find_new(
       collection->client, collection->ns, filter, opts, read_prefs, collection->read_prefs, collection->read_concern);
+
+   _mongoc_cursor_check_db_name(cursor, collection->db);
+
+   return cursor;
 }
 
 
@@ -1102,6 +1107,7 @@ mongoc_collection_find_indexes_with_opts(mongoc_collection_t *collection, const 
    /* No read preference. Index Enumeration Spec: "run listIndexes on the
     * primary node in replicaSet mode". */
    cursor = _mongoc_cursor_cmd_new(collection->client, collection->ns, &cmd, opts, NULL, NULL, NULL);
+   _mongoc_cursor_check_db_name(cursor, collection->db);
 
    if (!mongoc_cursor_error(cursor, &error)) {
       _mongoc_cursor_prime(cursor);
@@ -2123,6 +2129,11 @@ mongoc_collection_rename_with_opts(mongoc_collection_t *collection,
                         MONGOC_ERROR_NAMESPACE_INVALID,
                         "\"%s\" is an invalid collection name.",
                         new_name);
+      return false;
+   }
+
+   // The "to" field below is a joined namespace, which the server splits at the first ".".
+   if (new_db && !_mongoc_validate_db_name(new_db, -1, error)) {
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-private.h
@@ -164,6 +164,10 @@ int32_t
 _mongoc_n_return(mongoc_cursor_t *cursor);
 void
 _mongoc_set_cursor_ns(mongoc_cursor_t *cursor, const char *ns, uint32_t nslen);
+// Set an error on the cursor if `db` is not a valid database name.
+// Useful since `_mongoc_set_cursor_ns` does not know if a "." is in the db (invalid) or collection (valid).
+bool
+_mongoc_cursor_check_db_name(mongoc_cursor_t *cursor, const char *db);
 bool
 _mongoc_cursor_get_opt_bool(const mongoc_cursor_t *cursor, const char *option);
 void

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -179,6 +179,21 @@ _mongoc_set_cursor_ns(mongoc_cursor_t *cursor, const char *ns, uint32_t nslen)
 }
 
 
+bool
+_mongoc_cursor_check_db_name(mongoc_cursor_t *cursor, const char *db)
+{
+   BSON_ASSERT_PARAM(cursor);
+   BSON_ASSERT_PARAM(db);
+
+   // Preserve an error already recorded by cursor construction.
+   if (CURSOR_FAILED(cursor)) {
+      return false;
+   }
+
+   return _mongoc_validate_db_name(db, -1, &cursor->error);
+}
+
+
 /* return first key beginning with $, or NULL. precondition: bson is valid. */
 static const char *
 _first_dollar_field(const bson_t *bson)

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -138,6 +138,7 @@ mongoc_database_aggregate(mongoc_database_t *db,                 /* IN */
 {
    return _mongoc_aggregate(db->client,
                             db->name,
+                            db->name,
                             MONGOC_QUERY_NONE,
                             pipeline,
                             opts,
@@ -688,6 +689,7 @@ mongoc_database_find_collections_with_opts(mongoc_database_t *database, const bs
    /* Enumerate Collections Spec: "run listCollections on the primary node in
     * replicaset mode" */
    cursor = _mongoc_cursor_cmd_new(database->client, database->name, &cmd, opts, NULL, NULL, NULL);
+   _mongoc_cursor_check_db_name(cursor, database->name);
    if (cursor->error.domain == 0) {
       _mongoc_cursor_prime(cursor);
    }

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -24,6 +24,7 @@
 #include <mongoc/mongoc-stream-gridfs-download-private.h>
 #include <mongoc/mongoc-stream-gridfs-upload-private.h>
 #include <mongoc/mongoc-stream-private.h>
+#include <mongoc/mongoc-util-private.h>
 #include <mongoc/mongoc-write-concern-private.h>
 
 #include <mongoc/mongoc.h>
@@ -95,6 +96,21 @@ mongoc_gridfs_bucket_new(mongoc_database_t *db,
    if (!_mongoc_gridfs_bucket_opts_parse(db->client, opts, &gridfs_opts, error)) {
       _mongoc_gridfs_bucket_opts_cleanup(&gridfs_opts);
       return NULL;
+   }
+
+   // Validate `bucketName` from the BSON options since it may contain an embedded NUL.
+   {
+      bson_iter_t iter;
+
+      if (opts && bson_iter_init_find(&iter, opts, "bucketName") && BSON_ITER_HOLDS_UTF8(&iter)) {
+         uint32_t bucket_name_len;
+         const char *const bucket_name = bson_iter_utf8(&iter, &bucket_name_len);
+
+         if (!_mongoc_validate_collection_name(bucket_name, bucket_name_len, error)) {
+            _mongoc_gridfs_bucket_opts_cleanup(&gridfs_opts);
+            return NULL;
+         }
+      }
    }
 
    /* Initialize the bucket fields */

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1535,6 +1535,15 @@ mongoc_uri_finalize_auth(mongoc_uri_t *uri, bson_error_t *error)
       return false;
    }
 
+   // Validate `authSource`:
+   {
+      bson_error_t validate_error;
+      if (source && !_mongoc_validate_db_name(source, -1, &validate_error)) {
+         MONGOC_URI_ERROR(error, "%s", validate_error.message);
+         return false;
+      }
+   }
+
    // Copy `mechanism` to avoid invalidation by updates to `uri->credentials`.
    char *const mechanism = bson_strdup(mongoc_uri_get_auth_mechanism(uri));
 
@@ -2448,6 +2457,12 @@ mongoc_uri_set_database(mongoc_uri_t *uri, const char *database)
       return false;
    }
 
+   // Match the validation applied to a database name parsed from the URI path. `_parse_path` rejects a larger set of
+   // characters; a "." is rejected here because it would silently retarget the namespace.
+   if (!_mongoc_validate_db_name_or_log(database)) {
+      return false;
+   }
+
    if (uri->database) {
       bson_free(uri->database);
    }
@@ -2520,6 +2535,11 @@ mongoc_uri_set_auth_source(mongoc_uri_t *uri, const char *value)
    len = strlen(value);
 
    if (!bson_utf8_validate(value, len, false)) {
+      return false;
+   }
+
+   // `authSource` is a database name. See `mongoc_uri_finalize_auth`.
+   if (!_mongoc_validate_db_name_or_log(value)) {
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -98,6 +98,40 @@ _mongoc_validate_replace(const bson_t *insert, bson_validate_flags_t vflags, bso
 bool
 _mongoc_validate_update(const bson_t *update, bson_validate_flags_t vflags, bson_error_t *error);
 
+/**
+ * @brief Validate a database name argument.
+ *
+ * Rejects a "." (the driver joins `db + "." + collection` into a namespace that the server splits at the first ".",
+ * so the server would never see the intended database name) and an embedded NUL byte (the name is truncated by the
+ * C string and wire protocol cstring encodings). Other characters prohibited by the MongoDB manual are forwarded
+ * faithfully and are left for the server to reject.
+ *
+ * @param db The database name to validate.
+ * @param db_len The length of @p db in bytes, or a negative value if @p db is NUL-terminated.
+ * @param error Optional out-parameter for the error.
+ * @return true if @p db is a usable database name.
+ */
+bool
+_mongoc_validate_db_name(const char *db, int64_t db_len, bson_error_t *error);
+
+/**
+ * @brief Validate a collection name argument.
+ *
+ * Rejects an embedded NUL byte. A "." is permitted in a collection name.
+ *
+ * @param collection The collection name to validate.
+ * @param collection_len The length of @p collection in bytes, or a negative value if @p collection is NUL-terminated.
+ * @param error Optional out-parameter for the error.
+ * @return true if @p collection is a usable collection name.
+ */
+bool
+_mongoc_validate_collection_name(const char *collection, int64_t collection_len, bson_error_t *error);
+
+// _mongoc_validate_db_name_or_log validates a NUL-terminated database name, logging the error at the ERROR level if
+// invalid. For use by APIs that have no `bson_error_t` out-parameter.
+bool
+_mongoc_validate_db_name_or_log(const char *db);
+
 bool
 mongoc_ends_with(const char *str, const char *suffix);
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -46,6 +46,7 @@
 #include <windows.h>
 #endif
 
+#include <limits.h>
 #include <string.h>
 
 /**
@@ -427,6 +428,81 @@ _mongoc_validate_update(const bson_t *update, bson_validate_flags_t vflags, bson
 
          return false;
       }
+   }
+
+   return true;
+}
+
+
+// _validate_name checks a database or collection name argument for characters the driver's own encoding cannot
+// faithfully forward to the server. See `_mongoc_validate_db_name` and `_mongoc_validate_collection_name`.
+static bool
+_validate_name(const char *name, int64_t name_len, bool is_db, bson_error_t *error)
+{
+   BSON_ASSERT_PARAM(name);
+   BSON_OPTIONAL_PARAM(error);
+
+   size_t len = 0;
+   if (name_len < 0) {
+      len = strlen(name);
+   } else if (mlib_in_range(size_t, name_len)) {
+      len = (size_t)name_len;
+   } else {
+      _mongoc_set_error(error,
+                        MONGOC_ERROR_NAMESPACE,
+                        MONGOC_ERROR_NAMESPACE_INVALID,
+                        "%s name invalid: too large",
+                        is_db ? "database" : "collection");
+      return false;
+   }
+
+   if (memchr(name, '\0', len)) {
+      _mongoc_set_error(error,
+                        MONGOC_ERROR_NAMESPACE,
+                        MONGOC_ERROR_NAMESPACE_INVALID,
+                        "%s name invalid: contains a NUL byte",
+                        is_db ? "database" : "collection");
+      return false;
+   }
+
+   if (is_db && memchr(name, '.', len)) {
+      const int print_len = mlib_in_range(int, len) ? (int)len : INT_MAX;
+
+      _mongoc_set_error(error,
+                        MONGOC_ERROR_NAMESPACE,
+                        MONGOC_ERROR_NAMESPACE_INVALID,
+                        "database name \"%.*s\" invalid: contains \".\"",
+                        print_len,
+                        name);
+      return false;
+   }
+
+   return true;
+}
+
+
+bool
+_mongoc_validate_db_name(const char *db, int64_t db_len, bson_error_t *error)
+{
+   return _validate_name(db, db_len, true /* is_db */, error);
+}
+
+
+bool
+_mongoc_validate_collection_name(const char *collection, int64_t collection_len, bson_error_t *error)
+{
+   return _validate_name(collection, collection_len, false /* is_db */, error);
+}
+
+
+bool
+_mongoc_validate_db_name_or_log(const char *db)
+{
+   bson_error_t error;
+
+   if (!_mongoc_validate_db_name(db, -1, &error)) {
+      MONGOC_ERROR("%s", error.message);
+      return false;
    }
 
    return true;

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -119,6 +119,7 @@ main(int argc, char *argv[])
    TEST_INSTALL(test_uri_install);
    TEST_INSTALL(test_usleep_install);
    TEST_INSTALL(test_util_install);
+   TEST_INSTALL(test_ns_validation_install);
    TEST_INSTALL(test_version_install);
    TEST_INSTALL(test_with_transaction_install);
    TEST_INSTALL(test_write_concern_install);

--- a/src/libmongoc/tests/test-mongoc-crud.c
+++ b/src/libmongoc/tests/test-mongoc-crud.c
@@ -1260,6 +1260,45 @@ prose_test_12(void *ctx)
 }
 
 static void
+prose_test_17(void)
+{
+   /*
+   17. Ensure database and collection is validated
+   */
+   mongoc_client_t *const client = test_framework_new_default_client();
+   bson_t *const doc = bson_new();
+   bson_error_t error;
+
+   // Ensure operations accepting a database string result in a client-side error if containing ".":
+   //    client["foo.bar"]["coll"].insert_one({})
+   {
+      mongoc_collection_t *const coll = mongoc_client_get_collection(client, "foo.bar", "coll");
+
+      ASSERT(!mongoc_collection_insert_one(coll, doc, NULL, NULL, &error));
+      ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_NAMESPACE, MONGOC_ERROR_NAMESPACE_INVALID, "invalid: contains \".\"");
+
+      mongoc_collection_destroy(coll);
+   }
+
+   /* The remaining assertions of prose test 17 concern a name containing a NUL byte:
+    *    client["foo\0bar"]["coll"].insert_one({})
+    *    client["db"]["foo\0bar"].insert_one({})
+    *    client.bulk_write([InsertOne(namespace="foo\0bar.coll", document={})])
+    *    client.bulk_write([InsertOne(namespace="db.foo\0bar", document={})])
+    *
+    * These are not expressible in C. `mongoc_client_get_database`, `mongoc_database_get_collection` and
+    * `mongoc_bulkwrite_append_insertone` all accept a NUL-terminated `const char *`, so a caller cannot pass a name
+    * that contains a NUL byte: "foo\0bar" is indistinguishable from "foo" at the API boundary, and the truncation has
+    * already happened in the caller. There is no behavior left for libmongoc to assert here.
+    *
+    * The surfaces where libmongoc does receive a name with an explicit length, and so can observe an embedded NUL,
+    * are covered by `/ns_validation/gridfs_bucket`. */
+
+   bson_destroy(doc);
+   mongoc_client_destroy(client);
+}
+
+static void
 prose_test_15(void *ctx)
 {
    /*
@@ -1475,4 +1514,6 @@ test_crud_install(TestSuite *suite)
                      NULL /* ctx */,
                      test_framework_skip_if_max_wire_version_less_than_25 // require server 8.0
    );
+
+   TestSuite_AddLive(suite, "/crud/prose_test_17 [lock:live-server]", prose_test_17);
 }

--- a/src/libmongoc/tests/test-mongoc-ns-validation.c
+++ b/src/libmongoc/tests/test-mongoc-ns-validation.c
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Tests for the validation of database and collection name arguments. A "." in a database name and a NUL byte in
+ * either name cannot be faithfully forwarded to the server, and are rejected. A "." in a collection name is
+ * permitted. See DRIVERS-3600.
+ *
+ * The handle constructors (`mongoc_client_get_database` and friends) still accept any name: they have no
+ * `bson_error_t` out-parameter and have never returned NULL. Rejection happens when an operation is performed. */
+
+#include <mongoc/mongoc.h>
+
+#include <TestSuite.h>
+#include <test-conveniences.h>
+#include <test-libmongoc.h>
+
+#define BAD_DB "db.bad"
+#define EXPECT_BAD_DB(error) \
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_NAMESPACE, MONGOC_ERROR_NAMESPACE_INVALID, "invalid: contains \".\"")
+
+/* A handle for an invalid database name is still created: that behavior is unchanged. */
+static void
+test_ns_validation_handles_still_created(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+
+   mongoc_database_t *const db = mongoc_client_get_database(client, BAD_DB);
+   ASSERT(db);
+   ASSERT_CMPSTR(mongoc_database_get_name(db), BAD_DB);
+
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, BAD_DB, "coll");
+   ASSERT(coll);
+
+   mongoc_collection_t *const coll2 = mongoc_database_get_collection(db, "coll");
+   ASSERT(coll2);
+
+   mongoc_collection_destroy(coll2);
+   mongoc_collection_destroy(coll);
+   mongoc_database_destroy(db);
+   mongoc_client_destroy(client);
+}
+
+/* A "." in a collection name is unambiguous within a namespace, and stays legal. */
+static void
+test_ns_validation_dotted_collection_ok(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, "db", "coll.with.dots");
+   bson_error_t error;
+
+   ASSERT_CMPSTR(mongoc_collection_get_name(coll), "coll.with.dots");
+
+   /* No client-side error: only an invalid database name is rejected. */
+   bson_t *const filter = bson_new();
+   mongoc_cursor_t *const cursor = mongoc_collection_find_with_opts(coll, filter, NULL, NULL);
+   ASSERT(!mongoc_cursor_error(cursor, &error));
+
+   mongoc_cursor_destroy(cursor);
+   bson_destroy(filter);
+   mongoc_collection_destroy(coll);
+   mongoc_client_destroy(client);
+}
+
+/* Reads go through a cursor. `_mongoc_set_cursor_ns` splits the namespace at the first ".", so the check must happen
+ * where the database and collection names are still separate. The error surfaces via `mongoc_cursor_error` without any
+ * server round trip. */
+static void
+test_ns_validation_cursors(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   mongoc_database_t *const db = mongoc_client_get_database(client, BAD_DB);
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, BAD_DB, "coll");
+   bson_t *const empty = bson_new();
+   bson_error_t error;
+   mongoc_cursor_t *cursor;
+
+   cursor = mongoc_collection_find_with_opts(coll, empty, NULL, NULL);
+   ASSERT(mongoc_cursor_error(cursor, &error));
+   EXPECT_BAD_DB(error);
+   mongoc_cursor_destroy(cursor);
+
+   cursor = mongoc_collection_aggregate(coll, MONGOC_QUERY_NONE, empty, NULL, NULL);
+   ASSERT(mongoc_cursor_error(cursor, &error));
+   EXPECT_BAD_DB(error);
+   mongoc_cursor_destroy(cursor);
+
+   cursor = mongoc_collection_find_indexes_with_opts(coll, NULL);
+   ASSERT(mongoc_cursor_error(cursor, &error));
+   EXPECT_BAD_DB(error);
+   mongoc_cursor_destroy(cursor);
+
+   cursor = mongoc_database_aggregate(db, empty, NULL, NULL);
+   ASSERT(mongoc_cursor_error(cursor, &error));
+   EXPECT_BAD_DB(error);
+   mongoc_cursor_destroy(cursor);
+
+   cursor = mongoc_database_find_collections_with_opts(db, NULL);
+   ASSERT(mongoc_cursor_error(cursor, &error));
+   EXPECT_BAD_DB(error);
+   mongoc_cursor_destroy(cursor);
+
+   bson_destroy(empty);
+   mongoc_collection_destroy(coll);
+   mongoc_database_destroy(db);
+   mongoc_client_destroy(client);
+}
+
+/* Commands and writes pass the database name to `mongoc_cmd_parts_assemble` whole, which is the common backstop. These
+ * require server selection to succeed first, so a live server is needed. */
+static void
+test_ns_validation_commands(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   mongoc_database_t *const db = mongoc_client_get_database(client, BAD_DB);
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, BAD_DB, "coll");
+   bson_error_t error;
+
+   // A raw command.
+   bson_t *const cmd = BCON_NEW("ping", BCON_INT32(1));
+   ASSERT(!mongoc_client_command_simple(client, BAD_DB, cmd, NULL, NULL, &error));
+   EXPECT_BAD_DB(error);
+   ASSERT(!mongoc_database_command_simple(db, cmd, NULL, NULL, &error));
+   EXPECT_BAD_DB(error);
+   bson_destroy(cmd);
+
+   // A write.
+   bson_t *const doc = BCON_NEW("_id", BCON_INT32(1));
+   ASSERT(!mongoc_collection_insert_one(coll, doc, NULL, NULL, &error));
+   EXPECT_BAD_DB(error);
+   bson_destroy(doc);
+
+   // A command-based collection helper.
+   ASSERT(!mongoc_collection_drop(coll, &error));
+   EXPECT_BAD_DB(error);
+
+   // A change stream: `_make_cursor` runs "aggregate" through the command path.
+   bson_t *const empty = bson_new();
+   mongoc_change_stream_t *const stream = mongoc_collection_watch(coll, empty, NULL);
+   ASSERT(mongoc_change_stream_error_document(stream, &error, NULL));
+   EXPECT_BAD_DB(error);
+   mongoc_change_stream_destroy(stream);
+   bson_destroy(empty);
+
+   mongoc_collection_destroy(coll);
+   mongoc_database_destroy(db);
+   mongoc_client_destroy(client);
+}
+
+static void
+test_ns_validation_rename(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, "db", "coll");
+   bson_error_t error;
+
+   ASSERT(!mongoc_collection_rename(coll, BAD_DB, "coll", false /* drop_target_before_rename */, &error));
+   EXPECT_BAD_DB(error);
+
+   mongoc_collection_destroy(coll);
+   mongoc_client_destroy(client);
+}
+
+static void
+test_ns_validation_get_gridfs(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   bson_error_t error;
+
+   ASSERT(!mongoc_client_get_gridfs(client, BAD_DB, "fs", &error));
+   EXPECT_BAD_DB(error);
+
+   mongoc_client_destroy(client);
+}
+
+static void
+test_ns_validation_gridfs_bucket(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   mongoc_database_t *const db = mongoc_client_get_database(client, "db");
+   bson_error_t error;
+
+   /* `bucketName` is read from a BSON string, so unlike every other name argument it can carry an embedded NUL. Without
+    * validation, "fs\0bad" is truncated to the "fs.files" and "fs.chunks" collections. */
+   bson_t *const opts = bson_new();
+   ASSERT(bson_append_utf8(opts, "bucketName", -1, "fs\0bad", 6));
+
+   ASSERT(!mongoc_gridfs_bucket_new(db, opts, NULL /* read_prefs */, &error));
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_NAMESPACE, MONGOC_ERROR_NAMESPACE_INVALID, "invalid: contains a NUL byte");
+
+   // A "." in `bucketName` is permitted.
+   bson_t *const dotted_opts = BCON_NEW("bucketName", "fs.dotted");
+   mongoc_gridfs_bucket_t *const bucket = mongoc_gridfs_bucket_new(db, dotted_opts, NULL /* read_prefs */, &error);
+   ASSERT_OR_PRINT(bucket, error);
+
+   mongoc_gridfs_bucket_destroy(bucket);
+   bson_destroy(dotted_opts);
+   bson_destroy(opts);
+   mongoc_database_destroy(db);
+   mongoc_client_destroy(client);
+}
+
+static void
+test_ns_validation_uri_set_database(void)
+{
+   mongoc_uri_t *const uri = mongoc_uri_new("mongodb://localhost:27017");
+   ASSERT(uri);
+
+   /* `mongoc_uri_set_database` already returns false for an unusable name (e.g. invalid UTF-8), so rejecting here is
+    * in-contract. */
+   capture_logs(true);
+   ASSERT(!mongoc_uri_set_database(uri, BAD_DB));
+   ASSERT_CAPTURED_LOG("mongoc_uri_set_database", MONGOC_LOG_LEVEL_ERROR, "invalid: contains \".\"");
+   clear_captured_logs();
+
+   ASSERT(mongoc_uri_set_database(uri, "db"));
+   ASSERT_NO_CAPTURED_LOGS("mongoc_uri_set_database");
+   capture_logs(false);
+
+   ASSERT_CMPSTR(mongoc_uri_get_database(uri), "db");
+
+   mongoc_uri_destroy(uri);
+}
+
+static void
+test_ns_validation_uri_path(void)
+{
+   bson_error_t error;
+
+   // A "." in the URI path is rejected when parsing. This predates DRIVERS-3600.
+   ASSERT(!mongoc_uri_new_with_error("mongodb://localhost:27017/db.bad", &error));
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "disallowed characters");
+
+   // ... including when %-encoded.
+   ASSERT(!mongoc_uri_new_with_error("mongodb://localhost:27017/db%2Ebad", &error));
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "disallowed characters");
+
+   // A %-encoded NUL byte is rejected.
+   ASSERT(!mongoc_uri_new_with_error("mongodb://localhost:27017/db%00bad", &error));
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "null characters");
+}
+
+static void
+test_ns_validation_auth_source(void)
+{
+   bson_error_t error;
+
+   // `authSource` is a database name: it is joined with the username to form "saslSupportedMechs".
+   ASSERT(!mongoc_uri_new_with_error("mongodb://user:pwd@localhost:27017/?authSource=db.bad", &error));
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "invalid: contains \".\"");
+
+   mongoc_uri_t *const uri = mongoc_uri_new("mongodb://user:pwd@localhost:27017");
+   ASSERT(uri);
+
+   capture_logs(true);
+   ASSERT(!mongoc_uri_set_auth_source(uri, BAD_DB));
+   ASSERT_CAPTURED_LOG("mongoc_uri_set_auth_source", MONGOC_LOG_LEVEL_ERROR, "invalid: contains \".\"");
+   clear_captured_logs();
+
+   ASSERT(mongoc_uri_set_auth_source(uri, "$external"));
+   ASSERT_NO_CAPTURED_LOGS("mongoc_uri_set_auth_source");
+   capture_logs(false);
+
+   mongoc_uri_destroy(uri);
+}
+
+#ifdef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
+static void
+test_ns_validation_keyvault_namespace(void)
+{
+   mongoc_client_t *const client = test_framework_new_default_client();
+   bson_error_t error;
+
+   bson_t *const kms_providers =
+      BCON_NEW("local", "{", "key", BCON_BIN(BSON_SUBTYPE_BINARY, (uint8_t[96]){0}, 96), "}");
+
+   // A "." in the key vault database name would target a different key vault collection than requested.
+   {
+      mongoc_auto_encryption_opts_t *const opts = mongoc_auto_encryption_opts_new();
+      mongoc_auto_encryption_opts_set_keyvault_namespace(opts, "keyvault.bad", "datakeys");
+      mongoc_auto_encryption_opts_set_kms_providers(opts, kms_providers);
+
+      ASSERT(!mongoc_client_enable_auto_encryption(client, opts, &error));
+      EXPECT_BAD_DB(error);
+
+      mongoc_auto_encryption_opts_destroy(opts);
+   }
+
+   {
+      mongoc_client_encryption_opts_t *const opts = mongoc_client_encryption_opts_new();
+      mongoc_client_encryption_opts_set_keyvault_namespace(opts, "keyvault.bad", "datakeys");
+      mongoc_client_encryption_opts_set_keyvault_client(opts, client);
+      mongoc_client_encryption_opts_set_kms_providers(opts, kms_providers);
+
+      ASSERT(!mongoc_client_encryption_new(opts, &error));
+      EXPECT_BAD_DB(error);
+
+      mongoc_client_encryption_opts_destroy(opts);
+   }
+
+   bson_destroy(kms_providers);
+   mongoc_client_destroy(client);
+}
+#endif /* MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION */
+
+void
+test_ns_validation_install(TestSuite *suite)
+{
+   TestSuite_AddLive(suite, "/ns_validation/handles_still_created", test_ns_validation_handles_still_created);
+   TestSuite_AddLive(suite, "/ns_validation/dotted_collection_ok", test_ns_validation_dotted_collection_ok);
+   TestSuite_AddLive(suite, "/ns_validation/cursors", test_ns_validation_cursors);
+   TestSuite_AddLive(suite, "/ns_validation/commands", test_ns_validation_commands);
+   TestSuite_AddLive(suite, "/ns_validation/rename", test_ns_validation_rename);
+   TestSuite_AddLive(suite, "/ns_validation/get_gridfs", test_ns_validation_get_gridfs);
+   TestSuite_AddLive(suite, "/ns_validation/gridfs_bucket", test_ns_validation_gridfs_bucket);
+   TestSuite_Add(suite, "/ns_validation/uri_set_database", test_ns_validation_uri_set_database);
+   TestSuite_Add(suite, "/ns_validation/uri_path", test_ns_validation_uri_path);
+   TestSuite_Add(suite, "/ns_validation/auth_source", test_ns_validation_auth_source);
+#ifdef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
+   TestSuite_AddLive(suite, "/ns_validation/keyvault_namespace", test_ns_validation_keyvault_namespace);
+#endif
+}


### PR DESCRIPTION
A PR for this change was previously approved (see link in CDRIVER-6424). The fix was pushed to r2.5 in https://github.com/mongodb/mongo-c-driver/commit/81d0f794d07224c53f815ceb59daed28103dcf3d. This PR applies the changes to master (this is notably a reverse of our typical merge process).