### PR TITLE
CDRIVER-6174 restore S3 upload of Debian package build artifacts

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -10,6 +10,7 @@ from shrub.v3.evg_command import (
     KeyValueParam,
     ec2_assume_role,
     expansions_update,
+    s3_put,
     subprocess_exec,
 )
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
@@ -339,7 +340,28 @@ def tasks() -> Iterable[EvgTask]:
             name=f'debian-package-{plat}',
             commands=[
                 DockerLoginAmazonECR.call(),
+                # An explicit invocation of deb.packages is needed so that the
+                # earthly COPY .. AS LOCAL will copy the artifact out into the filesystem
+                earthly_exec(kind='test', target='deb.packages', platform=f'linux/{plat}'),
                 earthly_exec(kind='test', target='deb.test', platform=f'linux/{plat}'),
+                s3_put(
+                    aws_key='${aws_key}',
+                    aws_secret='${aws_secret}',
+                    remote_file='${project}/${branch_name}/mongo-c-driver-debian-packages-' + plat + '-${CURRENT_VERSION}.tar.gz',
+                    bucket='mciuploads',
+                    permissions='public-read',
+                    local_file='mongoc/deb-pkg.tgz',
+                    content_type='${content_type|application/x-gzip}',
+                ),
+                s3_put(
+                    aws_key='${aws_key}',
+                    aws_secret='${aws_secret}',
+                    remote_file='${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-' + plat + '.tar.gz',
+                    bucket='mciuploads',
+                    permissions='public-read',
+                    local_file='mongoc/deb-pkg.tgz',
+                    content_type='${content_type|application/x-gzip}',
+                ),
             ],
             tags=['packaging', 'pr-merge-gate'],
             run_on=CONTAINER_RUN_DISTROS,

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5064,9 +5064,40 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - --platform=linux/amd64
+            - +deb.packages
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
+          args:
+            - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
+            - --platform=linux/amd64
             - +deb.test
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          bucket: mciuploads
+          content_type: ${content_type|application/x-gzip}
+          local_file: mongoc/deb-pkg.tgz
+          permissions: public-read
+          remote_file: ${project}/${branch_name}/mongo-c-driver-debian-packages-amd64-${CURRENT_VERSION}.tar.gz
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          bucket: mciuploads
+          content_type: ${content_type|application/x-gzip}
+          local_file: mongoc/deb-pkg.tgz
+          permissions: public-read
+          remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-amd64.tar.gz
   - name: debian-package-i386
     run_on:
       - amazon2
@@ -5087,9 +5118,40 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - --platform=linux/i386
+            - +deb.packages
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
+          args:
+            - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
+            - --platform=linux/i386
             - +deb.test
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          bucket: mciuploads
+          content_type: ${content_type|application/x-gzip}
+          local_file: mongoc/deb-pkg.tgz
+          permissions: public-read
+          remote_file: ${project}/${branch_name}/mongo-c-driver-debian-packages-i386-${CURRENT_VERSION}.tar.gz
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          bucket: mciuploads
+          content_type: ${content_type|application/x-gzip}
+          local_file: mongoc/deb-pkg.tgz
+          permissions: public-read
+          remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-i386.tar.gz
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check

--- a/Earthfile
+++ b/Earthfile
@@ -400,6 +400,7 @@ deb.packages:
         git -C $MCD_DIR commit --no-verify --allow-empty --message "Working changes for Debian package build"
     # Run the build
     RUN bash /tmp/build.sh
+    RUN tar zcvf $MCD_DIR/../deb-pkg.tgz $MCD_DIR/../*.deb
     # Save all build results to the output
     SAVE ARTIFACT $MCD_DIR/../*.build /
     SAVE ARTIFACT $MCD_DIR/../*.buildinfo /
@@ -408,6 +409,7 @@ deb.packages:
     SAVE ARTIFACT $MCD_DIR/../*.dsc /
     SAVE ARTIFACT $MCD_DIR/../*.tar.gz /
     SAVE ARTIFACT $MCD_DIR/../*.tar.xz /
+    SAVE ARTIFACT $MCD_DIR/../deb-pkg.tgz AS LOCAL deb-pkg.tgz
 
 deb.test:
     ARG debian_version = "unstable"


### PR DESCRIPTION
Follow up for e37e1232bfd9575c84686a7178946530d45206fd

This PR restores the upload of Debian package build artifacts to S3 as those artifacts are required for the corresponding Debian package build tasks in the C++ driver.

Evergreen patch build: https://spruce.corp.mongodb.com/version/6a95dc3be8c487000741a16c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC