### PR TITLE
Format Python scripts

### DIFF
--- a/.evergreen/config_generator/components/funcs/csfle_setup.py
+++ b/.evergreen/config_generator/components/funcs/csfle_setup.py
@@ -38,9 +38,7 @@ class CSFLESetup(Function):
             command_type=command_type,
             working_dir='drivers-evergreen-tools/.evergreen/csfle',
             include_expansions_in_env=['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'],
-            env={
-                'FLE_AZURE_USE_CORPORATE': 'YES'
-            },
+            env={'FLE_AZURE_USE_CORPORATE': 'YES'},
             script='./setup.sh',  # Creates secrets-export.sh. Starts servers on ports 5698, 9000, 9001, 9002, and 9003.
         ),
     ]

--- a/.evergreen/config_generator/components/unicode_compile.py
+++ b/.evergreen/config_generator/components/unicode_compile.py
@@ -8,7 +8,7 @@ from config_generator.etc.utils import bash_exec
 # Compile-only task for CDRIVER-6346: build on Windows with UNICODE/_UNICODE defined.
 
 # Enable C4133 as error to identify string pointer mismatch.
-_UNICODE_FLAGS = "/we4133 /DUNICODE /D_UNICODE"
+_UNICODE_FLAGS = '/we4133 /DUNICODE /D_UNICODE'
 
 
 def tasks():


### PR DESCRIPTION
Minor format fixes via `uv run --frozen tools/ruff-format-all.sh`.