### PR TITLE
CDRIVER-6405 fix unsafe calls to bson_next_power_of_two

### DIFF
--- a/src/common/src/common-bits-private.h
+++ b/src/common/src/common-bits-private.h
@@ -47,4 +47,32 @@ mcommon_next_power_of_two_u32(uint32_t v)
 }
 
 
+// Round up to the next power of two size_t value. Saturates on overflow.
+static BSON_INLINE size_t
+mcommon_next_power_of_two_size_t(size_t v)
+{
+   if (v == 0) {
+      return 1;
+   }
+
+   // https://graphics.stanford.edu/%7Eseander/bithacks.html#RoundUpPowerOf2
+   v--;
+   v |= v >> 1;
+   v |= v >> 2;
+   v |= v >> 4;
+   v |= v >> 8;
+   v |= v >> 16;
+#if SIZE_MAX > 0xFFFFFFFFu
+   v |= v >> 32;
+#endif
+   v++;
+
+   if (v == 0) {
+      return SIZE_MAX;
+   } else {
+      return v;
+   }
+}
+
+
 #endif /* MONGO_C_DRIVER_COMMON_BITS_PRIVATE_H */

--- a/src/common/tests/test-common-bits.c
+++ b/src/common/tests/test-common-bits.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <common-bits-private.h>
+
+#include <TestSuite.h>
+
+static void
+test_mcommon_next_power_of_two_u32(void)
+{
+   BSON_ASSERT(mcommon_next_power_of_two_u32(0u) == 1u);
+   BSON_ASSERT(mcommon_next_power_of_two_u32(1u) == 1u);
+   BSON_ASSERT(mcommon_next_power_of_two_u32(3u) == 4u);
+   BSON_ASSERT(mcommon_next_power_of_two_u32(UINT32_C(0x80000000)) == UINT32_C(0x80000000));
+
+   // Test saturation:
+   BSON_ASSERT(mcommon_next_power_of_two_u32(UINT32_C(0x80000001)) == UINT32_MAX);
+   BSON_ASSERT(mcommon_next_power_of_two_u32(UINT32_MAX) == UINT32_MAX);
+}
+
+static void
+test_mcommon_next_power_of_two_size_t(void)
+{
+   const size_t max_two_power = (SIZE_MAX >> 1u) + 1u;
+
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(0u) == 1u);
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(1u) == 1u);
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(3u) == 4u);
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(max_two_power) == max_two_power);
+
+   // Test saturation:
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(max_two_power + 1u) == SIZE_MAX);
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(SIZE_MAX - 1u) == SIZE_MAX);
+   BSON_ASSERT(mcommon_next_power_of_two_size_t(SIZE_MAX) == SIZE_MAX);
+}
+
+void
+test_mcommon_bits_install(TestSuite *suite)
+{
+   TestSuite_Add(suite, "/mcommon/bits/next_power_of_two/u32", test_mcommon_next_power_of_two_u32);
+   TestSuite_Add(suite, "/mcommon/bits/next_power_of_two/size_t", test_mcommon_next_power_of_two_size_t);
+}

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -21,10 +21,12 @@
 #include <bson/bson-iso8601-private.h>
 #include <bson/bson-json-private.h>
 #include <common-b64-private.h>
+#include <common-bits-private.h>
 
 #include <bson/bson.h>
 #include <bson/config.h>
 
+#include <mlib/ckdint.h>
 #include <mlib/cmp.h>
 #include <mlib/config.h>
 
@@ -478,7 +480,7 @@ _bson_json_buf_ensure(bson_json_buf_t *buf, /* IN */
    if (buf->n_bytes < len) {
       bson_free(buf->buf);
 
-      buf->n_bytes = bson_next_power_of_two(len);
+      buf->n_bytes = mcommon_next_power_of_two_size_t(len);
       buf->buf = bson_malloc(buf->n_bytes);
    }
 }
@@ -487,7 +489,9 @@ _bson_json_buf_ensure(bson_json_buf_t *buf, /* IN */
 static void
 _bson_json_buf_set(bson_json_buf_t *buf, const void *from, size_t len)
 {
-   _bson_json_buf_ensure(buf, len + 1);
+   const size_t len_with_null = mlib_assert_add(size_t, len, 1u);
+
+   _bson_json_buf_ensure(buf, len_with_null);
    memcpy(buf->buf, from, len);
    buf->buf[len] = '\0';
    buf->len = len;
@@ -497,13 +501,17 @@ _bson_json_buf_set(bson_json_buf_t *buf, const void *from, size_t len)
 static void
 _bson_json_buf_append(bson_json_buf_t *buf, const void *from, size_t len)
 {
-   size_t len_with_null = len + 1;
+   const size_t len_with_null = mlib_assert_add(size_t, len, 1u);
 
    if (buf->len == 0) {
       _bson_json_buf_ensure(buf, len_with_null);
-   } else if (buf->n_bytes < buf->len + len_with_null) {
-      buf->n_bytes = bson_next_power_of_two(buf->len + len_with_null);
-      buf->buf = bson_realloc(buf->buf, buf->n_bytes);
+   } else {
+      const size_t needed = mlib_assert_add(size_t, buf->len, len_with_null);
+
+      if (buf->n_bytes < needed) {
+         buf->n_bytes = mcommon_next_power_of_two_size_t(needed);
+         buf->buf = bson_realloc(buf->buf, buf->n_bytes);
+      }
    }
 
    memcpy(buf->buf + buf->len, from, len);

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1016,6 +1016,7 @@ endif ()
 
 set (test-libmongoc-sources
    ${mongo-c-driver_SOURCE_DIR}/src/common/tests/test-common-atomic.c
+   ${mongo-c-driver_SOURCE_DIR}/src/common/tests/test-common-bits.c
    ${mongo-c-driver_SOURCE_DIR}/src/common/tests/test-mlib.c
    ${mongo-c-driver_SOURCE_DIR}/src/common/tests/test-common-oid.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/corpus-test.c

--- a/src/libmongoc/src/mongoc/mongoc-array.c
+++ b/src/libmongoc/src/mongoc/mongoc-array.c
@@ -15,7 +15,10 @@
  */
 
 
+#include <common-bits-private.h>
 #include <mongoc/mongoc-array-private.h>
+
+#include <mlib/ckdint.h>
 
 
 void
@@ -100,10 +103,13 @@ _mongoc_array_append_vals(mongoc_array_t *array, const void *data, uint32_t n_el
    BSON_ASSERT(array);
    BSON_ASSERT(data);
 
-   off = array->element_size * array->len;
-   len = (size_t)n_elements * array->element_size;
-   if ((off + len) > array->allocated) {
-      next_size = bson_next_power_of_two(off + len);
+   off = mlib_assert_mul(size_t, array->element_size, array->len);
+   len = mlib_assert_mul(size_t, (size_t)n_elements, array->element_size);
+
+   const size_t needed = mlib_assert_add(size_t, off, len);
+
+   if (needed > array->allocated) {
+      next_size = mcommon_next_power_of_two_size_t(needed);
 
       if (array->element_alignment == 0) {
          array->data = bson_realloc(array->data, next_size);

--- a/src/libmongoc/src/mongoc/mongoc-buffer.c
+++ b/src/libmongoc/src/mongoc/mongoc-buffer.c
@@ -15,12 +15,14 @@
  */
 
 
+#include <common-bits-private.h>
 #include <mongoc/mongoc-buffer-private.h>
 #include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-trace-private.h>
 
 #include <bson/bson.h>
 
+#include <mlib/ckdint.h>
 #include <mlib/cmp.h>
 
 #include <stdarg.h>
@@ -37,8 +39,10 @@
 static void
 make_space_for(mongoc_buffer_t *buffer, size_t data_size)
 {
-   if (buffer->len + data_size > buffer->datalen) {
-      buffer->datalen = bson_next_power_of_two(buffer->len + data_size);
+   const size_t needed = mlib_assert_add(size_t, buffer->len, data_size);
+
+   if (needed > buffer->datalen) {
+      buffer->datalen = mcommon_next_power_of_two_size_t(needed);
       buffer->data = (uint8_t *)buffer->realloc_func(buffer->data, buffer->datalen, buffer->realloc_data);
    }
 }

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -18,6 +18,7 @@
 
 #ifdef MONGOC_ENABLE_SSL_SECURE_CHANNEL
 
+#include <common-bits-private.h>
 #include <common-string-private.h>
 #include <mongoc/mongoc-crypto-private.h> // mongoc_crypto_hash
 #include <mongoc/mongoc-errno-private.h>
@@ -749,7 +750,7 @@ mongoc_secure_channel_write(mongoc_stream_tls_t *tls, const void *data, size_t d
 void
 mongoc_secure_channel_realloc_buf(size_t *size, uint8_t **buf, size_t new_size)
 {
-   *size = bson_next_power_of_two(new_size);
+   *size = mcommon_next_power_of_two_size_t(new_size);
    *buf = bson_realloc(*buf, *size);
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <common-bits-private.h>
 #include <common-oid-private.h>
 #include <mongoc/mongoc-array-private.h>
 #include <mongoc/mongoc-client-private.h>
@@ -146,7 +147,7 @@ _mongoc_topology_description_copy_to(const mongoc_topology_description_t *src, m
    dst->heartbeat_msec = src->heartbeat_msec;
    dst->rand_seed = src->rand_seed;
 
-   nitems = bson_next_power_of_two(mc_tpld_servers_const(src)->items_len);
+   nitems = mcommon_next_power_of_two_size_t(mc_tpld_servers_const(src)->items_len);
    dst->_servers_ = mongoc_set_new(nitems, _mongoc_topology_server_dtor, NULL);
    for (size_t i = 0u; i < mc_tpld_servers_const(src)->items_len; i++) {
       sd = mongoc_set_get_item_and_id_const(mc_tpld_servers_const(src), i, &id);

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -49,6 +49,7 @@ main(int argc, char *argv[])
    TEST_INSTALL(test_writer_install);
    TEST_INSTALL(test_b64_install);
    TEST_INSTALL(test_mcommon_atomic_install);
+   TEST_INSTALL(test_mcommon_bits_install);
    TEST_INSTALL(test_mcommon_oid_install);
    TEST_INSTALL(test_mlib_install);
 


### PR DESCRIPTION
A PR for this change was previously approved (see link in ticket). The fix was pushed to the release branch first. This PR applies the changes to master (this is notably a reverse of our typical merge process).