### PR TITLE
CDRIVER-6407 check vlen before int cast in JSON parser

### DIFF
--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -727,6 +727,11 @@ _bson_json_read_integer(bson_json_reader_t *reader, uint64_t val, int64_t sign)
 static bool
 _bson_json_parse_double(bson_json_reader_t *reader, const char *val, size_t vlen, double *d)
 {
+   if (!mlib_in_range(int, vlen)) {
+      _bson_json_read_corrupt(reader, "string length out of range");
+      return false;
+   }
+
    errno = 0;
    *d = strtod(val, NULL);
 
@@ -837,6 +842,11 @@ _bson_json_parse_binary_elem(bson_json_reader_t *reader, const char *val_w_null,
    int binary_len;
 
    BASIC_CB_PREAMBLE;
+
+   if (!mlib_in_range(int, vlen)) {
+      _bson_json_read_corrupt(reader, "string length out of range");
+      return;
+   }
 
    bs = bson->bson_state;
    data = &bson->bson_type_data;
@@ -966,6 +976,11 @@ _bson_json_read_string(bson_json_reader_t *reader, /* IN */
 
    rs = bson->read_state;
    bs = bson->bson_state;
+
+   if (!mlib_in_range(int, vlen)) {
+      _bson_json_read_corrupt(reader, "string length out of range");
+      return;
+   }
 
    if (!bson_utf8_validate((const char *)val, vlen, allow_null)) {
       _bson_json_read_corrupt(reader, "invalid bytes in UTF8 string");

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -14,6 +14,7 @@
 
 #include <TestSuite.h>
 #include <test-conveniences.h>
+#include <test-libmongoc.h>
 
 #include <math.h>
 
@@ -3790,6 +3791,37 @@ test_bson_as_json_all_formats(void)
 }
 
 
+// Regression test for CDRIVER-6405:
+static void
+test_json_big_string(void *ctx)
+{
+   BSON_UNUSED(ctx);
+
+   // Create a JSON string like { "a": "b\0" + "c" * INT32_MAX ) }
+   static const char prefix[] = "{ \"a\": \"b\\u0000";
+   static const char suffix[] = "\" }";
+   const size_t prefix_len = sizeof prefix - 1u;
+   const size_t suffix_len = sizeof suffix - 1u;
+   const size_t filler_len = (size_t)INT32_MAX;
+   const size_t json_str_len = prefix_len + filler_len + suffix_len;
+
+   char *json_str = bson_malloc(json_str_len + 1u);
+   memcpy(json_str, prefix, prefix_len);
+   memset(json_str + prefix_len, 'c', filler_len);
+   memcpy(json_str + prefix_len + filler_len, suffix, suffix_len);
+   json_str[json_str_len] = '\0';
+
+   // Try to parse with bson_init_from_json
+   bson_t b;
+   bson_error_t error = {0};
+   BSON_ASSERT(mlib_in_range(ssize_t, json_str_len));
+   const bool ok = bson_init_from_json(&b, json_str, (ssize_t)json_str_len, &error);
+   // Expect error:
+   ASSERT(!ok);
+   ASSERT_ERROR_CONTAINS(error, BSON_ERROR_JSON, BSON_JSON_ERROR_READ_CORRUPT_JS, "string length out of range");
+   bson_free(json_str);
+}
+
 void
 test_json_install(TestSuite *suite)
 {
@@ -3895,4 +3927,5 @@ test_json_install(TestSuite *suite)
    TestSuite_Add(suite, "/bson/parse_array", test_parse_array);
    TestSuite_Add(suite, "/bson/decimal128_overflowing_exponent", test_decimal128_overflowing_exponent);
    TestSuite_Add(suite, "/bson/as_json/all_formats", test_bson_as_json_all_formats);
+   TestSuite_AddFull(suite, "/bson/json/big_string", test_json_big_string, NULL, NULL, skip_if_no_large_allocations);
 }


### PR DESCRIPTION
A PR for this change was previously approved (see link in ticket). The fix was pushed to the release branch first. This PR applies the changes to master (this is notably a reverse of our typical merge process).