### PR TITLE
CDRIVER-6409 fix OCSP double free

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1171,6 +1171,7 @@ if (MONGOC_ENABLE_SSL)
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-x509.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-ocsp-cache.c
+      ${PROJECT_SOURCE_DIR}/tests/test-mongoc-ocsp.c
    )
 endif ()
 

--- a/src/libmongoc/src/mongoc/mongoc-openssl-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-openssl-private.h
@@ -30,6 +30,7 @@
 #include <openssl/ssl.h>
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_OCSP) && !defined(LIBRESSL_VERSION_NUMBER)
+#include <openssl/ocsp.h>
 #define MONGOC_ENABLE_OCSP_OPENSSL
 #endif
 
@@ -48,6 +49,8 @@ _mongoc_openssl_cleanup(void);
 #ifdef MONGOC_ENABLE_OCSP_OPENSSL
 int
 _mongoc_ocsp_tlsext_status(SSL *ssl, mongoc_openssl_ocsp_opt_t *opts);
+OCSP_RESPONSE *
+_mongoc_contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts, int *ocsp_uri_count);
 #endif
 
 bool

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -631,15 +631,12 @@ _get_must_staple(X509 *cert)
 #define ERR_STR (ERR_error_string(ERR_get_error(), NULL))
 #define MONGOC_OCSP_REQUEST_TIMEOUT mlib_duration(5, s)
 
-static OCSP_RESPONSE *
-_contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts, int *ocsp_uri_count)
+OCSP_RESPONSE *
+_mongoc_contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts, int *ocsp_uri_count)
 {
    STACK_OF(OPENSSL_STRING) *url_stack = NULL;
-   OPENSSL_STRING url = NULL, host = NULL, path = NULL, port = NULL;
-   OCSP_REQUEST *req = NULL;
-   const unsigned char *resp_data;
    OCSP_RESPONSE *resp = NULL;
-   int i, ssl;
+   int i;
 
    url_stack = X509_get1_ocsp(peer);
    *ocsp_uri_count = sk_OPENSSL_STRING_num(url_stack);
@@ -652,9 +649,12 @@ _contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts,
 
       _mongoc_http_request_init(&http_req);
       _mongoc_http_response_init(&http_res);
-      url = sk_OPENSSL_STRING_value(url_stack, i);
+      const OPENSSL_STRING url = sk_OPENSSL_STRING_value(url_stack, i);
       TRACE("Contacting OCSP responder '%s'", url);
 
+      OCSP_REQUEST *req = NULL;
+      OPENSSL_STRING host = NULL, path = NULL, port = NULL;
+      int ssl;
       /* splits the given url into its host, port and path components */
       if (!OCSP_parse_url(url, &host, &port, &path, &ssl)) {
          MONGOC_DEBUG("Could not parse URL");
@@ -697,7 +697,7 @@ _contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts,
          GOTO(retry);
       }
 
-      resp_data = (const unsigned char *)http_res.body;
+      const unsigned char *resp_data = (const unsigned char *)http_res.body;
 
       if (http_res.body_len == 0 || !d2i_OCSP_RESPONSE(&resp, &resp_data, http_res.body_len)) {
          MONGOC_DEBUG("Could not parse OCSP response from HTTP response");
@@ -706,21 +706,15 @@ _contact_ocsp_responder(OCSP_CERTID *id, X509 *peer, mongoc_ssl_opt_t *ssl_opts,
       }
 
    retry:
-      if (host)
-         OPENSSL_free(host);
-      if (port)
-         OPENSSL_free(port);
-      if (path)
-         OPENSSL_free(path);
-      if (req)
-         OCSP_REQUEST_free(req);
-      if (request_der)
-         OPENSSL_free(request_der);
+      OPENSSL_free(host);
+      OPENSSL_free(port);
+      OPENSSL_free(path);
+      OCSP_REQUEST_free(req);
+      OPENSSL_free(request_der);
       _mongoc_http_response_cleanup(&http_res);
    }
 
-   if (url_stack)
-      X509_email_free(url_stack);
+   X509_email_free(url_stack);
    RETURN(resp);
 }
 
@@ -801,7 +795,7 @@ _mongoc_ocsp_tlsext_status(SSL *ssl, mongoc_openssl_ocsp_opt_t *opts)
       }
 
       if (opts->disable_endpoint_check ||
-          !(resp = _contact_ocsp_responder(id, peer, &opts->ssl_opts, &ocsp_uri_count))) {
+          !(resp = _mongoc_contact_ocsp_responder(id, peer, &opts->ssl_opts, &ocsp_uri_count))) {
          if (ocsp_uri_count > 0) {
             /* Only log a soft failure if there were OCSP responders listed in
              * the certificate. */

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -2,6 +2,11 @@
 
 #include <mongoc/mongoc.h>
 
+/* For MONGOC_ENABLE_OCSP_OPENSSL, which gates the OCSP test suites below. */
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+#include <mongoc/mongoc-openssl-private.h>
+#endif
+
 #include <bson/bson.h>
 
 #include <TestSuite.h>
@@ -141,6 +146,7 @@ main(int argc, char *argv[])
    TEST_INSTALL(test_streamable_hello_install);
 #if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
    TEST_INSTALL(test_ocsp_cache_install);
+   TEST_INSTALL(test_ocsp_install);
 #endif
    TEST_INSTALL(test_interrupt_install);
    TEST_INSTALL(test_monitoring_install);

--- a/src/libmongoc/tests/test-mongoc-ocsp.c
+++ b/src/libmongoc/tests/test-mongoc-ocsp.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mongoc/mongoc-config.h>
+
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+#include <mongoc/mongoc-openssl-private.h>
+#endif
+
+#include <TestSuite.h>
+
+#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
+
+#include <openssl/x509v3.h>
+
+/* Appends an id-ad-ocsp accessLocation with the given URI to `aia`. The URI is
+ * not validated, so a deliberately malformed URI may be used. */
+static void
+add_ocsp_uri(AUTHORITY_INFO_ACCESS *aia, const char *uri)
+{
+   ACCESS_DESCRIPTION *const ad = ACCESS_DESCRIPTION_new();
+   BSON_ASSERT(ad);
+
+   ASN1_OBJECT_free(ad->method);
+   ad->method = OBJ_nid2obj(NID_ad_OCSP);
+
+   ASN1_IA5STRING *const ia5 = ASN1_IA5STRING_new();
+   BSON_ASSERT(ia5);
+   BSON_ASSERT(ASN1_STRING_set(ia5, uri, -1));
+   GENERAL_NAME_set0_value(ad->location, GEN_URI, ia5);
+
+   BSON_ASSERT(sk_ACCESS_DESCRIPTION_push(aia, ad));
+}
+
+/* Returns a certificate whose Authority Information Access extension lists
+ * `uris` as OCSP responder URIs, in order. */
+static X509 *
+cert_with_ocsp_uris(const char *const *uris, size_t uris_len)
+{
+   X509 *const cert = X509_new();
+   BSON_ASSERT(cert);
+
+   AUTHORITY_INFO_ACCESS *const aia = AUTHORITY_INFO_ACCESS_new();
+   BSON_ASSERT(aia);
+   for (size_t i = 0; i < uris_len; i++) {
+      add_ocsp_uri(aia, uris[i]);
+   }
+
+   BSON_ASSERT(X509_add1_ext_i2d(cert, NID_info_access, aia, 0 /* not critical */, 0 /* flags */));
+   AUTHORITY_INFO_ACCESS_free(aia);
+
+   return cert;
+}
+
+/* Regression test for CDRIVER-6409 */
+static void
+test_ocsp_responder_url_parse_errors(void)
+{
+   const char *const uris[] = {
+      "http://localhost:1/",     /* Parses; request is allocated, then freed. */
+      "http://localhost:99999/", /* Port out of range: fails OCSP_parse_url
+                                  * before the request is reallocated. */
+   };
+
+   X509 *const cert = cert_with_ocsp_uris(uris, sizeof(uris) / sizeof(uris[0]));
+   mongoc_ssl_opt_t ssl_opts = {0};
+   int ocsp_uri_count = 0;
+
+   /* A NULL cert ID makes the first URI fail after the OCSP_REQUEST is
+    * allocated, without any HTTP traffic. */
+   OCSP_RESPONSE *const resp = _mongoc_contact_ocsp_responder(NULL /* id */, cert, &ssl_opts, &ocsp_uri_count);
+
+   ASSERT_CMPINT(ocsp_uri_count, ==, 2);
+   BSON_ASSERT(!resp);
+
+   X509_free(cert);
+}
+
+void
+test_ocsp_install(TestSuite *suite)
+{
+   TestSuite_Add(suite, "/OCSP/responder/url_parse_errors", test_ocsp_responder_url_parse_errors);
+}
+
+#else
+/* ensure the translation unit is not empty */
+extern int no_mongoc_ocsp_responder;
+#endif /* MONGOC_ENABLE_OCSP_OPENSSL */


### PR DESCRIPTION
A PR for this change was previously approved (see link in ticket). The fix was pushed to the release branch first. This PR applies the changes to master (this is notably a reverse of our typical merge process).