### PR TITLE
CDRIVER-6457 migrate Azure / GCP tests to Debian 12 / Ubuntu 22

### DIFF
--- a/.evergreen/config_generator/components/oidc.py
+++ b/.evergreen/config_generator/components/oidc.py
@@ -188,7 +188,8 @@ def tasks():
         ),
         EvgTask(
             name='oidc-gcp-auth-test-task',
-            run_on=['debian11-small'],  # TODO: switch to 'debian11-latest' after DEVPROD-23011 fixed.
+            # Must match the GCE VM image family (GCPKMS_IMAGEFAMILY in DET).
+            run_on=['debian12-latest-small'],
             commands=[
                 FetchSource.call(),
                 bash_exec(

--- a/.evergreen/config_generator/components/oidc.py
+++ b/.evergreen/config_generator/components/oidc.py
@@ -165,7 +165,9 @@ def tasks():
         ),
         EvgTask(
             name='oidc-azure-auth-test-task',
-            run_on=['debian11-small'],  # TODO: switch to 'debian11-latest' after DEVPROD-23011 fixed.
+            # The Azure VM image (AZUREOIDC_IMAGE in DET) is Debian 12. Debian 12 hosts lack a
+            # working `az` (DEVPROD-23011), so use Ubuntu 22.04, which also has OpenSSL 3.
+            run_on=['ubuntu2204-small'],
             commands=[
                 FetchSource.call(),
                 bash_exec(

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -13296,7 +13296,7 @@ buildvariants:
   batchtime: 20160
 - name: testgcpkms-variant
   display_name: GCP KMS
-  run_on: debian11-latest-small
+  run_on: debian12-latest-small
   tasks:
   - testgcpkms_task_group
   - testgcpkms-fail-task

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -13289,7 +13289,7 @@ buildvariants:
   - .versioned-api .8.0
 - name: testazurekms-variant
   display_name: Azure KMS
-  run_on: debian11-small
+  run_on: ubuntu2204-small
   tasks:
   - testazurekms_task_group
   - testazurekms-fail-task

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5550,7 +5550,7 @@ tasks:
             - ./drivers-evergreen-tools/.evergreen/auth_oidc/azure/run-driver-test.sh
   - name: oidc-gcp-auth-test-task
     run_on:
-      - debian11-small
+      - debian12-latest-small
     commands:
       - func: fetch-source
       - command: subprocess.exec

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5522,7 +5522,7 @@ tasks:
       - func: run-tests
   - name: oidc-azure-auth-test-task
     run_on:
-      - debian11-small
+      - ubuntu2204-small
     commands:
       - func: fetch-source
       - command: subprocess.exec

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -100,8 +100,10 @@ def _create_variant():
     return Variant(
         name='testazurekms-variant',
         display_name='Azure KMS',
-        # Azure Virtual Machine created is Debian 11.
-        run_on='debian11-small',  # TODO: switch to 'debian11-latest-small' after DEVPROD-23011 fixed.
+        # The Azure VM image (AZUREKMS_IMAGE in DET) is Debian 12, so the host must provide a
+        # compatible OpenSSL 3 to build the test binary. Debian 12 hosts lack a working `az`
+        # (DEVPROD-23011), so use Ubuntu 22.04, which has both.
+        run_on='ubuntu2204-small',
         tasks=['testazurekms_task_group', 'testazurekms-fail-task'],
         batchtime=20160,
     )  # Use a batchtime of 14 days as suggested by the CSFLE test README

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testgcpkms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testgcpkms.py
@@ -95,7 +95,7 @@ def _create_variant():
     return Variant(
         name='testgcpkms-variant',
         display_name='GCP KMS',
-        run_on='debian11-latest-small',  # GCP Virtual Machine is actually Debian 11.
+        run_on='debian12-latest-small',  # GCP Virtual Machine is actually Debian 12.
         tasks=['testgcpkms_task_group', 'testgcpkms-fail-task'],
         batchtime=20160,
     )  # Use a batchtime of 14 days as suggested by the CSFLE test README


### PR DESCRIPTION
To fix failing tasks that start a remote Azure / GCP instance. DRIVERS-3631 recently switched to Debian 12 (since GCP dropped Debian 11).

Evergreen patch: https://spruce.corp.mongodb.com/version/6a9adf871e63540007bc866e