### PR TITLE
CDRIVER-6445 Add mongoac basic package features

### DIFF
--- a/src/libmongoac/CMakeLists.txt
+++ b/src/libmongoac/CMakeLists.txt
@@ -92,6 +92,54 @@ else ()
    set (MONGOAC_VERSION_PRERELEASE "")
 endif ()
 
+configure_file (
+   "${CMAKE_CURRENT_SOURCE_DIR}/include/mongoac/version.h.in"
+   "${include_dir}/mongoac/version.h"
+)
+
+set_source_files_properties ("${include_dir}/mongoac/version.h" PROPERTIES LANGUAGE C)
+
+set (mongoac_file_set_headers
+  FILE_SET HEADERS
+    BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"
+    FILES "${include_dir}/mongoac/version.h"
+)
+
+if ("$CACHE{ENABLE_SHARED}")
+  add_library (mongoac_shared INTERFACE)
+  set_target_properties (mongoac_shared PROPERTIES
+    EXPORT_NAME mongoac::shared
+    SOVERSION "${PROJECT_VERSION_MAJOR}"
+  )
+  target_sources (mongoac_shared INTERFACE ${mongoac_file_set_headers})
+  add_library (mongoac::shared ALIAS mongoac_shared)
+
+  install (TARGETS mongoac_shared EXPORT mongoac-targets
+    FILE_SET HEADERS DESTINATION "${MONGOAC_INSTALL_INCLUDEDIR}"
+  )
+endif ()
+
+if (NOT "$CACHE{ENABLE_STATIC}" STREQUAL "OFF")
+  add_library (mongoac_static INTERFACE)
+  set_target_properties (mongoac_static PROPERTIES EXPORT_NAME mongoac::static)
+  target_compile_definitions (mongoac_static INTERFACE MONGOAC_STATIC)
+  target_sources (mongoac_static INTERFACE ${mongoac_file_set_headers})
+  add_library (mongoac::static ALIAS mongoac_static)
+
+  if ("$CACHE{ENABLE_STATIC}" STREQUAL "ON")
+    install (TARGETS mongoac_static EXPORT mongoac-targets
+      FILE_SET HEADERS DESTINATION "${MONGOAC_INSTALL_INCLUDEDIR}"
+    )
+  endif ()
+endif ()
+
+if ("$CACHE{ENABLE_SHARED}" OR "$CACHE{ENABLE_STATIC}" STREQUAL "ON")
+  install (EXPORT mongoac-targets
+    FILE mongoac-targets.cmake
+    DESTINATION "${MONGOAC_INSTALL_CMAKEDIR}"
+  )
+endif ()
+
 if (ENABLE_MAN_PAGES OR ENABLE_HTML_DOCS)
    find_package (Sphinx REQUIRED)
    add_subdirectory (doc)

--- a/src/libmongoac/CMakeLists.txt
+++ b/src/libmongoac/CMakeLists.txt
@@ -96,6 +96,7 @@ configure_file (
    "${CMAKE_CURRENT_SOURCE_DIR}/include/mongoac/version.h.in"
    "${include_dir}/mongoac/version.h"
 )
+set (soname "$CACHE{MONGOAC_OUTPUT_BASENAME}${PROJECT_VERSION_MAJOR}")
 
 set_source_files_properties ("${include_dir}/mongoac/version.h" PROPERTIES LANGUAGE C)
 
@@ -139,6 +140,8 @@ if ("$CACHE{ENABLE_SHARED}" OR "$CACHE{ENABLE_STATIC}" STREQUAL "ON")
     DESTINATION "${MONGOAC_INSTALL_CMAKEDIR}"
   )
 endif ()
+
+add_subdirectory (cmake)
 
 if (ENABLE_MAN_PAGES OR ENABLE_HTML_DOCS)
    find_package (Sphinx REQUIRED)

--- a/src/libmongoac/cmake/CMakeLists.txt
+++ b/src/libmongoac/cmake/CMakeLists.txt
@@ -1,0 +1,81 @@
+include (CMakePackageConfigHelpers)
+
+# Generate and install modern CMake package config files.
+block ()
+  write_basic_package_version_file (
+    mongoacConfigVersion.cmake
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion
+  )
+
+  configure_file (
+    mongoacConfig.cmake.in
+    mongoacConfig.cmake
+    @ONLY
+  )
+
+  install (
+    FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfigVersion.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfig.cmake"
+    DESTINATION "${MONGOAC_INSTALL_CMAKEDIR}"
+  )
+endblock ()
+
+# Generate and install pkg-config package config files.
+block ()
+  function (mongoac_install_pkg_config TARGET LINK_TYPE)
+    set (output_name "$CACHE{MONGOAC_OUTPUT_BASENAME}")
+
+    if (LINK_TYPE STREQUAL "STATIC")
+      set (is_static 1)
+      set (pcfilename "${CMAKE_CURRENT_BINARY_DIR}/${output_name}-static.pc")
+    else ()
+      set (is_static 0)
+      set (pcfilename "${CMAKE_CURRENT_BINARY_DIR}/${output_name}.pc")
+    endif ()
+
+    add_custom_command (
+      OUTPUT ${pcfilename}
+      COMMAND
+        ${CMAKE_COMMAND}
+          -D "src_dir=${CMAKE_CURRENT_SOURCE_DIR}"
+          -D "bin_dir=${CMAKE_CURRENT_BINARY_DIR}"
+          -D "prefix=${CMAKE_INSTALL_PREFIX}"
+          -D "includedir=${MONGOAC_INSTALL_INCLUDEDIR}"
+          -D "libdir=${CMAKE_INSTALL_LIBDIR}"
+          -D "output_name=${output_name}"
+          -D "soname=${soname}"
+          -D "version=${PROJECT_VERSION}"
+          -D "is_static=${is_static}"
+          -P ${CMAKE_CURRENT_SOURCE_DIR}/generate-pc.cmake
+      MAIN_DEPENDENCY
+        ${CMAKE_CURRENT_SOURCE_DIR}/mongoac.pc.in
+      DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/generate-pc.cmake
+    )
+
+    add_custom_target (generate-${TARGET}-pc ALL DEPENDS ${pcfilename})
+    add_dependencies (${TARGET} generate-${TARGET}-pc)
+
+    if (is_static)
+      set (pkgname "$CACHE{MONGOAC_OUTPUT_BASENAME}${PROJECT_VERSION_MAJOR}-static.pc")
+    else ()
+      set (pkgname "$CACHE{MONGOAC_OUTPUT_BASENAME}${PROJECT_VERSION_MAJOR}.pc")
+    endif ()
+
+    install (
+      FILES "${pcfilename}"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+      RENAME "${pkgname}"
+    )
+  endfunction ()
+
+  if ("$CACHE{ENABLE_SHARED}")
+    mongoac_install_pkg_config (mongoac_shared SHARED)
+  endif ()
+
+  if ("$CACHE{ENABLE_STATIC}" STREQUAL "ON")
+    mongoac_install_pkg_config (mongoac_static STATIC)
+  endif ()
+endblock ()

--- a/src/libmongoac/cmake/CMakeLists.txt
+++ b/src/libmongoac/cmake/CMakeLists.txt
@@ -14,12 +14,14 @@ block ()
     @ONLY
   )
 
-  install (
-    FILES
-      "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfigVersion.cmake"
-      "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfig.cmake"
-    DESTINATION "${MONGOAC_INSTALL_CMAKEDIR}"
-  )
+  if ("$CACHE{ENABLE_SHARED}" OR "$CACHE{ENABLE_STATIC}" STREQUAL "ON")
+    install (
+      FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/mongoacConfig.cmake"
+      DESTINATION "${MONGOAC_INSTALL_CMAKEDIR}"
+    )
+  endif ()
 endblock ()
 
 # Generate and install pkg-config package config files.

--- a/src/libmongoac/cmake/generate-pc.cmake
+++ b/src/libmongoac/cmake/generate-pc.cmake
@@ -1,0 +1,36 @@
+set (input_vars
+  src_dir
+  bin_dir
+  prefix
+  includedir
+  libdir
+  output_name
+  soname
+  version
+  is_static
+)
+
+foreach (var ${input_vars})
+  if (NOT DEFINED "${var}")
+    message (FATAL_ERROR "${var} was not set!")
+  endif ()
+endforeach ()
+
+set (cflags "-I\${includedir}")
+
+if (is_static)
+  set (pkgname "libmongoac-static")
+  string (APPEND cflags " -DMONGOAC_STATIC")
+  set (libs "\${libdir}/lib${soname}.a")
+  set (pc_output "${bin_dir}/${output_name}-static.pc")
+else ()
+  set (pkgname "libmongoac")
+  set (libs "-L\${libdir} -l${soname}")
+  set (pc_output "${bin_dir}/${output_name}.pc")
+endif ()
+
+configure_file (
+  ${src_dir}/mongoac.pc.in
+  ${pc_output}
+  @ONLY
+)

--- a/src/libmongoac/cmake/mongoac.pc.in
+++ b/src/libmongoac/cmake/mongoac.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+includedir=${prefix}/@includedir@
+libdir=${prefix}/@libdir@
+
+Name: @pkgname@
+Description: The MongoDB Async C Driver library
+URL: https://github.com/mongodb/mongo-c-driver
+Version: @version@
+Cflags: @cflags@
+Libs: @libs@

--- a/src/libmongoac/cmake/mongoacConfig.cmake.in
+++ b/src/libmongoac/cmake/mongoacConfig.cmake.in
@@ -1,0 +1,2 @@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/mongoac-targets.cmake")

--- a/src/libmongoac/doc/CMakeLists.txt
+++ b/src/libmongoac/doc/CMakeLists.txt
@@ -1,1 +1,9 @@
-# TODO
+include (SphinxBuild)
+
+if (ENABLE_HTML_DOCS)
+   sphinx_build_html (mongoac-html mongoac)
+endif ()
+
+if (ENABLE_MAN_PAGES)
+   sphinx_build_man (mongoac-man)
+endif ()

--- a/src/libmongoac/doc/api.rst
+++ b/src/libmongoac/doc/api.rst
@@ -1,0 +1,6 @@
+API Reference
+=============
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1

--- a/src/libmongoac/doc/api.rst
+++ b/src/libmongoac/doc/api.rst
@@ -4,3 +4,5 @@ API Reference
 .. toctree::
    :titlesonly:
    :maxdepth: 1
+
+   mongoac/version

--- a/src/libmongoac/doc/conf.py
+++ b/src/libmongoac/doc/conf.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import os
+import os.path
+import sys
+
+# Ensure we can import "mongoc" extension module.
+this_path = os.path.dirname(__file__)
+sys.path.append(os.path.normpath(os.path.join(this_path, '../../../build/sphinx')))
+
+from mongoc_common import *  # noqa: E402, F403
+
+extensions = [
+    'mongoc',
+]
+
+# General information about the project.
+project = 'libmongoac'
+copyright = '2009-present, MongoDB, Inc.'
+author = 'MongoDB, Inc'
+
+version_path = os.path.join(os.path.dirname(__file__), '../', 'VERSION_CURRENT')  # src/libmongoac/VERSION_CURRENT
+version = open(version_path).read().strip()
+
+language = 'en'
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+master_doc = 'index'
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = 'furo'
+html_title = html_shorttitle = 'libmongoac %s' % version
+# html_favicon = None
+
+html_sidebars = {}
+
+html_use_index = False
+
+rst_prolog = r"""
+
+.. _mongodb_docs_cdriver: https://www.mongodb.com/docs/languages/c/c-driver/current/
+
+"""
+
+
+def add_canonical_link(app, pagename, templatename, context, doctree):
+    link = f'<link rel="canonical" href="https://www.mongoc.org/libmongoac/current/{pagename}"/>'
+
+    context['metatags'] = context.get('metatags', '') + link
+
+
+def setup(app):
+    mongoc_common_setup(app)  # noqa: F405
+    app.connect('html-page-context', add_canonical_link)

--- a/src/libmongoac/doc/index.rst
+++ b/src/libmongoac/doc/index.rst
@@ -23,7 +23,7 @@ To use a prebuilt mongoac library, the following requirements must be satisfied:
 - **CMake: 3.23 or newer**
     - The recommended method to import the mongoac library via ``find_package(mongoac)`` and targets ``mongoac::shared`` or ``mongoac::static``.
 - **pkgconf / pkg-config**
-    - An alternative to CMake via ``pkg-config`` (``libmongoac0.pc`` and ``libmongoac0-static.pc``).
+    - An alternative method to CMake via ``pkgconf`` or ``pkg-config`` (``mongoac0.pc`` and ``mongoac0-static.pc``).
 
 Build Requirements
 ------------------

--- a/src/libmongoac/doc/index.rst
+++ b/src/libmongoac/doc/index.rst
@@ -1,0 +1,57 @@
+libmongoac - API
+================
+
+The MongoDB Async C Driver.
+
+.. caution::
+
+  The mongoac library is **experimental** and not ready for production use!
+
+Introduction
+------------
+
+The MongoDB Async C Driver (mongoac) is an official MongoDB client library providing an asynchronous C API by wrapping the `MongoDB Rust Driver <https://www.mongodb.com/docs/drivers/rust/current/>`_.
+It is an independent async alternative to `MongoDB C Driver <https://www.mongodb.com/docs/drivers/c/current/>`_ (mongoc).
+
+Usage Requirements
+------------------
+
+To use a prebuilt mongoac library, the following requirements must be satisfied:
+
+- **C Compiler: C99 or newer**
+    - Required by all mongoac headers.
+- **CMake: 3.23 or newer**
+    - The recommended method to import the mongoac library via ``find_package(mongoac)`` and targets ``mongoac::shared`` or ``mongoac::static``.
+- **pkgconf / pkg-config**
+    - An alternative to CMake via ``pkg-config`` (``libmongoac0.pc`` and ``libmongoac0-static.pc``).
+
+Build Requirements
+------------------
+
+To build the mongoac library, it must be enabled by setting the CMake configuration option ``ENABLE_MONGOAC=ON``.
+
+When enabled, building the mongoac library requires the following toolchain dependencies:
+
+- **CMake: 3.25 or newer**
+    - Required to support file sets, path manipulation, and other features used for Rust Toolchain integration.
+- **Rust Toolchain: 1.88 or newer**
+    - Required to build the mongoac library implementation (written in Rust).
+    - The ``cargo`` executable is discovered using ``find_program()`` in CMake.
+    - See ``src/libmongoac/Cargo.toml`` for further details.
+- **C Compiler: GCC 8.1+, Clang 3.8+, AppleClang 13.1+ (Xcode 13.4.1+), or MSVC 19.16.27023+ (Visual Studio 2017 15.9+)**
+    - Required to build C components used by certain Rust crates (e.g. AWS-LC, zstd).
+    - Optional: required to validate headers when ``CMAKE_VERIFY_INTERFACE_HEADER_SETS=ON`` by building the CMake target ``mongoac_shared_verify_interface_header_sets`` or ``mongoac_static_verify_interface_header_sets``.
+- **C++ Compiler: C++17 or newer**
+    - Optional: only required to build ``test-libmongoac`` when ``ENABLE_TESTS=ON``.
+- **patchelf (Linux only)**
+    - Required to set the ``SONAME`` of the shared library; a warning is emitted when not found.
+    - Optional: only on Linux (per CMake variable ``LINUX``) when building the shared library (``ENABLE_SHARED=ON``).
+
+API Documentation
+-----------------
+
+.. toctree::
+  :titlesonly:
+  :maxdepth: 2
+
+  api

--- a/src/libmongoac/doc/mongoac/version.rst
+++ b/src/libmongoac/doc/mongoac/version.rst
@@ -1,0 +1,24 @@
+:man_page: mongoac_version
+
+mongoac_version
+===============
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   #define MONGOAC_VERSION            // e.g. "1.2.3-dev"
+   #define MONGOAC_VERSION_MAJOR      // e.g. 1
+   #define MONGOAC_VERSION_MINOR      // e.g. 2
+   #define MONGOAC_VERSION_PATCH      // e.g. 3
+   #define MONGOAC_VERSION_PRERELEASE // e.g. "dev" or ""
+
+   #define MONGOAC_VERSION_HEX // e.g. 0x01020300
+
+   #define MONGOAC_VERSION_CHECK(major, minor, patch)
+
+Description
+-----------
+
+Defines preprocessor macros describing the mongoac library version.

--- a/src/libmongoac/include/mongoac/version.h.in
+++ b/src/libmongoac/include/mongoac/version.h.in
@@ -1,0 +1,41 @@
+// Copyright 2009-present MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MONGOAC_VERSION_H
+#define MONGOAC_VERSION_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#define MONGOAC_VERSION_MAJOR (@mongoac_VERSION_MAJOR@)
+#define MONGOAC_VERSION_MINOR (@mongoac_VERSION_MINOR@)
+#define MONGOAC_VERSION_PATCH (@mongoac_VERSION_PATCH@)
+#define MONGOAC_VERSION_PRERELEASE "@MONGOAC_VERSION_PRERELEASE@"
+#define MONGOAC_VERSION "@MONGOAC_VERSION_FULL@"
+
+#define MONGOAC_VERSION_HEX (MONGOAC_VERSION_MAJOR << 24 | MONGOAC_VERSION_MINOR << 16 | MONGOAC_VERSION_PATCH << 8 | 0)
+
+#define MONGOAC_VERSION_CHECK(major, minor, patch)                                                              \
+   (MONGOAC_VERSION_MAJOR > (major) || (MONGOAC_VERSION_MAJOR == (major) && MONGOAC_VERSION_MINOR > (minor)) || \
+    (MONGOAC_VERSION_MAJOR == (major) && MONGOAC_VERSION_MINOR == (minor) && MONGOAC_VERSION_PATCH >= (patch)))
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif // MONGOAC_VERSION_H

--- a/src/libmongoac/include/mongoac/version.h.in
+++ b/src/libmongoac/include/mongoac/version.h.in
@@ -30,7 +30,7 @@ extern "C" {
 
 #define MONGOAC_VERSION_HEX (MONGOAC_VERSION_MAJOR << 24 | MONGOAC_VERSION_MINOR << 16 | MONGOAC_VERSION_PATCH << 8 | 0)
 
-#define MONGOAC_VERSION_CHECK(major, minor, patch)                                                              \
+#define MONGOAC_CHECK_VERSION(major, minor, patch)                                                              \
    (MONGOAC_VERSION_MAJOR > (major) || (MONGOAC_VERSION_MAJOR == (major) && MONGOAC_VERSION_MINOR > (minor)) || \
     (MONGOAC_VERSION_MAJOR == (major) && MONGOAC_VERSION_MINOR == (minor) && MONGOAC_VERSION_PATCH >= (patch)))
 


### PR DESCRIPTION
Partially resolves CDRIVER-6445. Adds minimal support structures for API doc pages, header installation, and package config files.

API doc pages work exactly the same way as existing bson and mongoc API doc page generation, just extended to the `src/libmongoac` directory. This PR makes no updates to the EVG configuration or release scripts to support publishing mongoac API doc pages yet.

This PR adds the first mongoac public header: `version.h`, generated by CMake via `configure_file()`. Accordingly, the `mongoac::shared` and `mongoac::static` library targets are defined (mirroring `mongoc::shared` and `mongoc::static`). However, these targets are (initially) defined as `INTERFACE` targets; they will eventually need to be refactored and redefined as `IMPORTED` targets later (see: [CDRIVER-6452](https://jira.mongodb.org/browse/CDRIVER-6452)). Note the shared vs. static library requirements also mirror existing requirements for bson and mongoc (e.g. the `MONGOAC_STATIC` preprocessor macro). Only preprocessor macros are defined: functions defined by `version.rs` are deferred to an upcoming PR.

The CMake and pkg-config package config files are defined using the same approach as the [C++ Driver](https://github.com/mongodb/mongo-cxx-driver/blob/19e493b4fdf3bc1fe352cda3a35d471e92aaacfd/src/mongocxx/cmake/CMakeLists.txt). Note these config files currently do not include any system library dependencies (i.e. `libm.so` is required by certain math-related Rust crates pulled in by the Rust Driver). We may consider eventually enumerating such external library dependencies going forward.