### PR TITLE
Also rename MONGOAC_CHECK_VERSION in doc pages

### DIFF
--- a/src/libmongoac/doc/mongoac/version.rst
+++ b/src/libmongoac/doc/mongoac/version.rst
@@ -16,7 +16,7 @@ Synopsis
 
    #define MONGOAC_VERSION_HEX // e.g. 0x01020300
 
-   #define MONGOAC_VERSION_CHECK(major, minor, patch)
+   #define MONGOAC_CHECK_VERSION(major, minor, patch)
 
 Description
 -----------


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2399 which overlooked the `version.rst` API doc page.