### PR TITLE
Add header origin to API doc page

### DIFF
--- a/src/libmongoac/doc/mongoac/version.rst
+++ b/src/libmongoac/doc/mongoac/version.rst
@@ -8,6 +8,8 @@ Synopsis
 
 .. code-block:: c
 
+   #include <mongoac/version.h>
+
    #define MONGOAC_VERSION            // e.g. "1.2.3-dev"
    #define MONGOAC_VERSION_MAJOR      // e.g. 1
    #define MONGOAC_VERSION_MINOR      // e.g. 2


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2399 and https://github.com/mongodb/mongo-c-driver/pull/2404, which overlooked the inclusion of the header providing the entities being documented (for consistency with bson and mongoc docs).