### PR TITLE
CDRIVER-6416 check size during SASL username canonicalization

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
@@ -51,6 +51,17 @@ struct _mongoc_cyrus_t {
 
 int
 _mongoc_cyrus_verifyfile_cb(void *context, const char *file, sasl_verify_type_t type);
+// `_mongoc_cyrus_canon_user` is the SASL_CB_CANON_USER callback. Exported for testing.
+int
+_mongoc_cyrus_canon_user(sasl_conn_t *conn,
+                         mongoc_cyrus_t *sasl,
+                         const char *in,
+                         unsigned inlen,
+                         unsigned flags,
+                         const char *user_realm,
+                         char *out,
+                         unsigned out_max,
+                         unsigned *out_len);
 void
 _mongoc_cyrus_init(mongoc_cyrus_t *sasl);
 bool

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -28,6 +28,7 @@
 
 #include <mlib/cmp.h>
 
+#include <limits.h>
 #include <string.h>
 
 #undef MONGOC_LOG_DOMAIN
@@ -97,7 +98,7 @@ _mongoc_cyrus_get_pass(mongoc_cyrus_t *sasl, int param_id, const char **result, 
 }
 
 
-static int
+int
 _mongoc_cyrus_canon_user(sasl_conn_t *conn,
                          mongoc_cyrus_t *sasl,
                          const char *in,
@@ -113,18 +114,19 @@ _mongoc_cyrus_canon_user(sasl_conn_t *conn,
    BSON_UNUSED(flags);
    BSON_UNUSED(user_realm);
 
-   // `inlen` is a string length (excluding trailing NULL).
-   // Cyrus-SASL passes an `out` buffer of size `out_max + 1`. Assume `out_max` is the max to be safe.
-   unsigned inlen_1 = 0;
-   if (mlib_add(&inlen_1, inlen, 1) || inlen_1 + 1 >= out_max) {
+   if (inlen > out_max) {
       MONGOC_ERROR("SASL username too large");
       return SASL_BUFOVER;
    }
 
-   TRACE("Canonicalizing %s (%" PRIu32 ")\n", in, inlen);
+   // Print with a precision: `in` is length-delimited, and Cyrus-SASL documents it as "may not be NUL terminated", so
+   // `%s` would read past the end. The precision argument is an `int`, and a negative one "is taken as if the precision
+   // were omitted" (C99 7.19.6.1) — quietly restoring that `%s` overread — so clamp rather than cast blindly. The check
+   // above already bounds `inlen` by `out_max`, so this only matters if a caller ever passes an `out_max` above
+   // `INT_MAX`.
+   TRACE("Canonicalizing %.*s (%u)\n", (int)BSON_MIN(inlen, (unsigned)INT_MAX), in, inlen);
    // Use memmove in case buffers overlap. From Cyrus-SASL: "output buffers and the input buffers may be the same"
    memmove(out, in, inlen);
-   out[inlen] = '\0';
    *out_len = inlen;
    return SASL_OK;
 }

--- a/src/libmongoc/tests/test-mongoc-cyrus.c
+++ b/src/libmongoc/tests/test-mongoc-cyrus.c
@@ -23,6 +23,8 @@
 #include <test-conveniences.h>
 #include <test-libmongoc.h>
 
+#include <limits.h>
+
 
 static void
 test_sasl_properties(void)
@@ -64,6 +66,74 @@ test_sasl_properties(void)
 }
 
 
+#define CANON_OUT_MAX 255u
+
+static void
+test_sasl_canon_user(void)
+{
+   char *const out = bson_malloc(CANON_OUT_MAX);
+   unsigned out_len = 0u;
+   const char in[] = {'u', 's', 'e', 'r'};
+
+   ASSERT_CMPINT(
+      _mongoc_cyrus_canon_user(NULL, NULL, in, sizeof in, 0u, NULL, out, CANON_OUT_MAX, &out_len), ==, SASL_OK);
+
+   // The output is deliberately not NUL terminated; Cyrus-SASL reads exactly `out_len` bytes.
+   ASSERT_CMPUINT(out_len, ==, (unsigned)sizeof in);
+   ASSERT(0 == memcmp(out, in, sizeof in));
+
+   bson_free(out);
+}
+
+// A username of exactly `out_max` bytes is a full-length username, not an overflow.
+static void
+test_sasl_canon_user_longest_accepted(void)
+{
+   const unsigned inlen = CANON_OUT_MAX;
+   char *const out = bson_malloc(inlen);
+   char *const in = bson_malloc(inlen);
+   unsigned out_len = 0u;
+
+   memset(in, 'x', inlen);
+
+   ASSERT_CMPINT(_mongoc_cyrus_canon_user(NULL, NULL, in, inlen, 0u, NULL, out, CANON_OUT_MAX, &out_len), ==, SASL_OK);
+
+   ASSERT_CMPUINT(out_len, ==, inlen);
+   ASSERT(0 == memcmp(out, in, inlen));
+
+   bson_free(in);
+   bson_free(out);
+}
+
+// Regression test for CDRIVER-6416.
+static void
+test_sasl_canon_user_too_large(void)
+{
+   const unsigned oversized[] = {CANON_OUT_MAX + 1u, UINT_MAX - 1u, UINT_MAX};
+
+   capture_logs(true);
+
+   for (size_t i = 0u; i < sizeof oversized / sizeof *oversized; i++) {
+      char *const out = bson_malloc(CANON_OUT_MAX);
+      unsigned out_len = 0u;
+      const char in[] = {'x'};
+
+      ASSERT_WITH_MSG(_mongoc_cyrus_canon_user(NULL, NULL, in, oversized[i], 0u, NULL, out, CANON_OUT_MAX, &out_len) ==
+                         SASL_BUFOVER,
+                      "expected SASL_BUFOVER for inlen %u",
+                      oversized[i]);
+
+      ASSERT_CAPTURED_LOG("oversized SASL username", MONGOC_LOG_LEVEL_ERROR, "SASL username too large");
+      clear_captured_logs();
+
+      bson_free(out);
+   }
+
+   capture_logs(false);
+}
+
+#undef CANON_OUT_MAX
+
 static void
 test_sasl_canonicalize_hostname(void *ctx)
 {
@@ -91,6 +161,9 @@ void
 test_cyrus_install(TestSuite *suite)
 {
    TestSuite_Add(suite, "/SASL/properties", test_sasl_properties);
+   TestSuite_Add(suite, "/SASL/canon_user", test_sasl_canon_user);
+   TestSuite_Add(suite, "/SASL/canon_user/longest_accepted", test_sasl_canon_user_longest_accepted);
+   TestSuite_Add(suite, "/SASL/canon_user/too_large", test_sasl_canon_user_too_large);
    TestSuite_AddFull(suite,
                      "/SASL/canonicalize [lock:live-server]",
                      test_sasl_canonicalize_hostname,


### PR DESCRIPTION
A PR for this change was previously approved (see link in ticket). The fix was pushed to the release branch first. This PR applies the changes to master (this is notably a reverse of our typical merge process).