### PR TITLE
don't attempt upload of i386 Debian artifacts (no longer built)

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -687,24 +687,6 @@ tasks:
       permissions: public-read
       local_file: deb.tar.gz
       content_type: ${content_type|application/x-gzip}
-  - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: mongo-c-driver/${branch_name}/mongo-c-driver-debian-packages-i386-${CURRENT_VERSION}.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: deb-i386.tar.gz
-      content_type: ${content_type|application/x-gzip}
-  - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: mongo-c-driver/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-i386.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: deb-i386.tar.gz
-      content_type: ${content_type|application/x-gzip}
 - name: rpm-package-build
   commands:
   - command: shell.exec

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -276,16 +276,6 @@ all_tasks = [
                 remote_file="${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz",
                 content_type="${content_type|application/x-gzip}",
             ),
-            s3_put(
-                local_file="deb-i386.tar.gz",
-                remote_file="${branch_name}/mongo-c-driver-debian-packages-i386-${CURRENT_VERSION}.tar.gz",
-                content_type="${content_type|application/x-gzip}",
-            ),
-            s3_put(
-                local_file="deb-i386.tar.gz",
-                remote_file="${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-i386.tar.gz",
-                content_type="${content_type|application/x-gzip}",
-            ),
         ],
     ),
     NamedTask(


### PR DESCRIPTION
Follow up for d3b789c604f9c8211e0355534a3a3fc7111bdf91

Evergreen patch build: https://spruce.corp.mongodb.com/version/6aa2d6796cd0880007957e90/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

(Sorry about this follow up. I should have waited for the Evergreen patch build on the last one.)